### PR TITLE
Fix RuntimeError

### DIFF
--- a/nextcord/ext/ipc/server.py
+++ b/nextcord/ext/ipc/server.py
@@ -250,7 +250,8 @@ class Server:
 
     def start(self):
         """Starts the IPC server."""
-        self.bot.dispatch("ipc_ready")
+        if self.bot.is_ready():
+            self.bot.dispatch("ipc_ready")
 
         self._server = aiohttp.web.Application()
         self._server.router.add_route("GET", "/", self.handle_accept)


### PR DESCRIPTION
The current version of nextcord raises RuntimeError if any event gets dispatched before bot is ready. 