### PR TITLE
Fix's #1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,9 @@ project = "nextcord-ext-ipc"
 copyright = "2021, Nextcord Developers"
 author = "Nextcord Developers"
 
-_version_regex = r"^version = ('|\")((?:[0-9]+\.)*[0-9]+(?:\.?([a-z]+)(?:\.?[0-9])?)?)\1$"
+_version_regex = (
+    r"^version = ('|\")((?:[0-9]+\.)*[0-9]+(?:\.?([a-z]+)(?:\.?[0-9])?)?)\1$"
+)
 
 with open("../nextcord/ext/ipc/__init__.py") as stream:
     match = re.search(_version_regex, stream.read(), re.MULTILINE)
@@ -15,12 +17,16 @@ if match.group(3) is not None:
     try:
         import subprocess
 
-        process = subprocess.Popen(["git", "rev-list", "--count", "HEAD"], stdout=subprocess.PIPE)
+        process = subprocess.Popen(
+            ["git", "rev-list", "--count", "HEAD"], stdout=subprocess.PIPE
+        )
         out, _ = process.communicate()
         if out:
             version += out.decode("utf-8").strip()
 
-        process = subprocess.Popen(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE)
+        process = subprocess.Popen(
+            ["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE
+        )
         out, _ = process.communicate()
         if out:
             version += "+g" + out.decode("utf-8").strip()

--- a/examples/basic-ipc/bot.py
+++ b/examples/basic-ipc/bot.py
@@ -26,7 +26,9 @@ my_bot = MyBot(command_prefix="!", intents=nextcord.Intents.all())
 
 @my_bot.ipc.route()
 async def get_member_count(data):
-    guild = my_bot.get_guild(data.guild_id)  # get the guild object using parsed guild_id
+    guild = my_bot.get_guild(
+        data.guild_id
+    )  # get the guild object using parsed guild_id
 
     return guild.member_count  # return the member count to the client
 

--- a/examples/basic-ipc/webserver.py
+++ b/examples/basic-ipc/webserver.py
@@ -3,7 +3,9 @@ from nextcord.ext import ipc
 
 
 app = Quart(__name__)
-ipc_client = ipc.Client(secret_key="my_secret_key")  # secret_key must be the same as your server
+ipc_client = ipc.Client(
+    secret_key="my_secret_key"
+)  # secret_key must be the same as your server
 
 
 @app.route("/")

--- a/examples/cog_based_ipc/bot.py
+++ b/examples/cog_based_ipc/bot.py
@@ -26,13 +26,6 @@ class MyBot(commands.Bot):
 my_bot = MyBot(command_prefix="!", intents=nextcord.Intents.all())
 
 
-@my_bot.command()
-async def r(ctx):
-    my_bot.reload_extension("cogs.ipc")
-    print(my_bot.ipc.endpoints)
-    await ctx.send("Reloaded")
-
-
 if __name__ == "__main__":
     my_bot.ipc.start()  # start the IPC Server
-    my_bot.run("NTExMzE5OTYzNTgwMTA0NzA1.W-i50w.u_aNK3gete6Xj88_XpP1Fj0HZkM")
+    my_bot.run("TOKEN")

--- a/examples/cog_based_ipc/bot.py
+++ b/examples/cog_based_ipc/bot.py
@@ -26,6 +26,13 @@ class MyBot(commands.Bot):
 my_bot = MyBot(command_prefix="!", intents=nextcord.Intents.all())
 
 
+@my_bot.command()
+async def r(ctx):
+    my_bot.reload_extension("cogs.ipc")
+    print(my_bot.ipc.endpoints)
+    await ctx.send("Reloaded")
+
+
 if __name__ == "__main__":
     my_bot.ipc.start()  # start the IPC Server
-    my_bot.run("TOKEN")
+    my_bot.run("NTExMzE5OTYzNTgwMTA0NzA1.W-i50w.u_aNK3gete6Xj88_XpP1Fj0HZkM")

--- a/examples/cog_based_ipc/cogs/ipc.py
+++ b/examples/cog_based_ipc/cogs/ipc.py
@@ -5,7 +5,7 @@ class IpcRoutes(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def ipc_member_count(self, data):
+    async def ipc_get_member_count(self, data):
         guild = self.bot.get_guild(
             data.guild_id
         )  # get the guild object using parsed guild_id

--- a/examples/cog_based_ipc/cogs/ipc.py
+++ b/examples/cog_based_ipc/cogs/ipc.py
@@ -5,9 +5,10 @@ class IpcRoutes(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @ipc.server.route()
-    async def get_member_count(self, data):
-        guild = self.bot.get_guild(data.guild_id)  # get the guild object using parsed guild_id
+    async def ipc_member_count(self, data):
+        guild = self.bot.get_guild(
+            data.guild_id
+        )  # get the guild object using parsed guild_id
 
         return guild.member_count  # return the member count to the client
 

--- a/examples/cog_based_ipc/webserver.py
+++ b/examples/cog_based_ipc/webserver.py
@@ -3,13 +3,15 @@ from nextcord.ext import ipc
 
 
 app = Quart(__name__)
-ipc_client = ipc.Client(secret_key="my_secret_key")  # secret_key must be the same as your server
+ipc_client = ipc.Client(
+    secret_key="my_secret_key"
+)  # secret_key must be the same as your server
 
 
 @app.route("/")
 async def index():
     member_count = await ipc_client.request(
-        "get_member_count", guild_id=12345678
+        "member_count", guild_id=500525882226769931  # TODO Remove
     )  # get the member count of server with ID 12345678
 
     return str(member_count)  # display member count

--- a/examples/cog_based_ipc/webserver.py
+++ b/examples/cog_based_ipc/webserver.py
@@ -11,7 +11,7 @@ ipc_client = ipc.Client(
 @app.route("/")
 async def index():
     member_count = await ipc_client.request(
-        "member_count", guild_id=500525882226769931  # TODO Remove
+        "get_member_count", guild_id=12345678
     )  # get the member count of server with ID 12345678
 
     return str(member_count)  # display member count

--- a/nextcord/ext/ipc/__init__.py
+++ b/nextcord/ext/ipc/__init__.py
@@ -5,7 +5,9 @@ from .server import Server
 from .errors import *
 
 
-_VersionInfo = collections.namedtuple("_VersionInfo", "major minor micro release serial")
+_VersionInfo = collections.namedtuple(
+    "_VersionInfo", "major minor micro release serial"
+)
 
 version = "1.0.0"
 version_info = _VersionInfo(1, 0, 0, "final", 0)

--- a/nextcord/ext/ipc/client.py
+++ b/nextcord/ext/ipc/client.py
@@ -21,7 +21,9 @@ class Client:
         The secret key for your IPC server. Must match the server secret_key or requests will not go ahead, defaults to None
     """
 
-    def __init__(self, host="localhost", port=None, multicast_port=20000, secret_key=None):
+    def __init__(
+        self, host="localhost", port=None, multicast_port=20000, secret_key=None
+    ):
         """Constructor"""
         self.loop = asyncio.get_event_loop()
 
@@ -39,7 +41,9 @@ class Client:
 
     @property
     def url(self):
-        return "ws://{0.host}:{1}".format(self, self.port if self.port else self.multicast_port)
+        return "ws://{0.host}:{1}".format(
+            self, self.port if self.port else self.multicast_port
+        )
 
     async def init_sock(self):
         """Attempts to connect to the server
@@ -76,7 +80,9 @@ class Client:
             port_data = recv.json()
             self.port = port_data["port"]
 
-        self.websocket = await self.session.ws_connect(self.url, autoping=False, autoclose=False)
+        self.websocket = await self.session.ws_connect(
+            self.url, autoping=False, autoclose=False
+        )
         log.info("Client connected to %s", self.url)
 
         return self.websocket

--- a/nextcord/ext/ipc/server.py
+++ b/nextcord/ext/ipc/server.py
@@ -134,6 +134,8 @@ class Server:
         request: :class:`~aiohttp.web.Request`
             The request made by the client, parsed by aiohttp.
         """
+        # TODO Fix / add this back
+        # self.bot.dispatch("ipc_ready")
         log.info("Initiating IPC Server.")
 
         websocket = aiohttp.web.WebSocketResponse()

--- a/nextcord/ext/ipc/server.py
+++ b/nextcord/ext/ipc/server.py
@@ -135,19 +135,16 @@ class Server:
             The request made by the client, parsed by aiohttp.
         """
         log.info("Initiating IPC Server.")
-        print("Init -> " + str(self.endpoints))
 
         websocket = aiohttp.web.WebSocketResponse()
         await websocket.prepare(request)
 
         async for message in websocket:
-            print("Incoming -> " + str(self.endpoints))
             request = message.json()
 
             log.debug("IPC Server < %r", request)
 
             endpoint = request.get("endpoint")
-            print("Requested -> " + endpoint)
 
             headers = request.get("headers")
 
@@ -157,31 +154,13 @@ class Server:
                 )
                 response = {"error": "Invalid or no token provided.", "code": 403}
             else:
-                if (
-                    not endpoint
-                    or endpoint not in self.endpoints
-                ):
+                if not endpoint or endpoint not in self.endpoints:
                     log.info("Received invalid request (Invalid or no endpoint given).")
                     response = {"error": "Invalid or no endpoint given.", "code": 400}
                 else:
                     server_response = IpcServerResponse(request)
-                    try:
-                        attempted_cls = self.bot.cogs.get(
-                            self.endpoints[endpoint].__qualname__.split(".")[
-                                0
-                            ]
-                        )
 
-                        if attempted_cls:
-                            arguments = (attempted_cls, server_response)
-                        else:
-                            arguments = (server_response,)
-                    except AttributeError:
-                        # Support base Client
-                        arguments = (server_response,)
-                    print(arguments)
                     try:
-                        #ret = await self.endpoints[endpoint](*arguments)
                         ret = await self.endpoints[endpoint](server_response)
                         response = ret
                     except Exception as error:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,9 @@ project_urls = {
     "Source": "https://github.com/nextcord/nextcord-ext-ipc",
 }
 
-_version_regex = r"^version = ('|\")((?:[0-9]+\.)*[0-9]+(?:\.?([a-z]+)(?:\.?[0-9])?)?)\1$"
+_version_regex = (
+    r"^version = ('|\")((?:[0-9]+\.)*[0-9]+(?:\.?([a-z]+)(?:\.?[0-9])?)?)\1$"
+)
 
 with open("nextcord/ext/ipc/__init__.py") as stream:
     match = re.search(_version_regex, stream.read(), re.MULTILINE)
@@ -59,12 +61,16 @@ if match.group(3) is not None:
     try:
         import subprocess
 
-        process = subprocess.Popen(["git", "rev-list", "--count", "HEAD"], stdout=subprocess.PIPE)
+        process = subprocess.Popen(
+            ["git", "rev-list", "--count", "HEAD"], stdout=subprocess.PIPE
+        )
         out, _ = process.communicate()
         if out:
             version += out.decode("utf-8").strip()
 
-        process = subprocess.Popen(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE)
+        process = subprocess.Popen(
+            ["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE
+        )
         out, _ = process.communicate()
         if out:
             version += "+g" + out.decode("utf-8").strip()


### PR DESCRIPTION
This resolves IPC routes being unable to be reloading when using the @route decorator. This also resolves my previous impl which broke the state between server instances.

This also fixes [this](https://github.com/Ext-Creators/discord-ext-ipc/issues/45) by grouping routes by Cog, which gives us the ability to hot-reload entire cogs and still maintain the correct state.

Note
------
The way this was fixed was by removing the decorator and instead automatically binding IPC routes within `bot.add_cog`

I have not documented these changes yet, as I wish to get feedback first as to whether or not these changes are something that could get approved. If not, I don't see the point putting more time into reworking docs etc
