### PR TITLE
Fix docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ py -3 -m pip install -U nextcord-ext-ipc
 
 ## Links 
 
-- [Documentation](https://nextcord-ext-ipc.readthedocs.io)
+- [Documentation](https://ipc.docs.nextcord.dev/)
 - [Usage Examples](https://github.com/nextcord/nextcord-ext-ipc/tree/master/examples)
 - [Support Discord Server](https://discord.gg/ZebatWssCB)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ py -3 -m pip install -U nextcord-ext-ipc
 
 - [Documentation](https://ipc.docs.nextcord.dev/)
 - [Usage Examples](https://github.com/nextcord/nextcord-ext-ipc/tree/master/examples)
-- [Support Discord Server](https://discord.gg/ZebatWssCB)
+- [Support Discord Server](https://discord.gg/nextcord)
 
 ## License
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ autodoc_typehints = "none"
 intersphinx_mapping = {
     "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
     "python": ("https://docs.python.org/3", None),
-    "nextcord": ("https://nextcord.readthedocs.io/en/latest", None),
+    "nextcord": ("https://docs.nextcord.dev/en/stable", None),
 }
 
 highlight_language = "python3"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ packages = [
 ]
 
 project_urls = {
-    "Documentation": "https://nextcord-ext-ipc.readthedocs.io",
+    "Documentation": "https://ipc.docs.nextcord.dev/",
     "Issue Tracker": "https://github.com/nextcord/nextcord-ext-ipc/issues",
     "Source": "https://github.com/nextcord/nextcord-ext-ipc",
 }


### PR DESCRIPTION
Use the new docs link `https://ipc.docs.nextcord.dev/` instead- in the readme.
I'm not sure if this needs to be changed elsewhere.

Closes #14