### PR TITLE
docs: Fix sphinx version causing an error building the docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ classifiers = [
 
 extras_require = {
     "docs": [
-        "sphinx<5.0.0",
+        "sphinx>=4.0.0,<6.0.0",
         "sphinxcontrib_trio",
         "sphinx-book-theme==0.3.3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ classifiers = [
 
 extras_require = {
     "docs": [
-        "sphinx>=5.0.0",
+        "sphinx<5.0.0",
         "sphinxcontrib_trio",
         "sphinx-book-theme==0.3.3",
     ],


### PR DESCRIPTION
It seems that the docs are currently failing due to a conflict caused by:

    nextcord-ext-ipc depends on sphinx>=5.0.0
    sphinx-book-theme 0.3.3 depends on sphinx<5 and >=3

I was pretty sure it was working locally in #18 but I may have installed things differently than I thought.

Either `sphinx-book-theme` and other dependencies can be updated to a newer commit supporting sphinx >= 5.0.0, or we can keep sphinx at < 5.0.0 for now.

Simpler yet may be to just leave off the version and allow the other dependencies to decide which version of sphinx will work.

<details>
<summary>Full build error</summary>
<pre>
/home/docs/checkouts/readthedocs.org/user_builds/nextcord-ext-ipc/envs/latest/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs]
Processing /home/docs/checkouts/readthedocs.org/user_builds/nextcord-ext-ipc/checkouts/latest
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting nextcord
  Downloading nextcord-2.2.0.tar.gz (932 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 932.5/932.5 kB 18.2 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: sphinx>=5.0.0 in /home/docs/checkouts/readthedocs.org/user_builds/nextcord-ext-ipc/envs/latest/lib/python3.8/site-packages (from nextcord-ext-ipc==2.2.1) (5.3.0)
Collecting sphinxcontrib_trio
  Downloading sphinxcontrib_trio-1.1.2-py3-none-any.whl (12 kB)
Collecting sphinx-book-theme==0.3.3
  Downloading sphinx_book_theme-0.3.3-py3-none-any.whl (345 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 345.7/345.7 kB 282.9 MB/s eta 0:00:00
INFO: pip is looking at multiple versions of nextcord-ext-ipc[docs] to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install nextcord-ext-ipc and nextcord-ext-ipc[docs]==2.2.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    nextcord-ext-ipc[docs] 2.2.1 depends on sphinx>=5.0.0
    sphinx-book-theme 0.3.3 depends on sphinx<5 and >=3

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
</pre>
</details>

----

> **Discussed on Discord:** ooliver says "there doesnt look to be any affecting breaking changes for 5.0.0, but probably best to lock it to >=4.0.0, <6.0.0"