### PR TITLE
fix(start): remove is_ready check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     name: Build
     runs-on: ubuntu-latest

--- a/nextcord/ext/ipc/server.py
+++ b/nextcord/ext/ipc/server.py
@@ -266,8 +266,7 @@ class Server:
 
     def start(self):
         """Starts the IPC server."""
-        if self.bot.is_ready():
-            self.bot.dispatch("ipc_ready")
+        self.bot.dispatch("ipc_ready")
 
         self._server = aiohttp.web.Application()
         self._server.router.add_route("GET", "/", self.handle_accept)


### PR DESCRIPTION
This is blocking on_ipc_ready from the example, and might confuse people when the bot is not ready and the event is not being fired. The PR simply removes the `bot.is_ready` check, since listeners are built up before the bot might be ready, as in the example the ipc server being started before bot.run.

The only way for creating an ipc server is starting it before the bot loop is running.