### PR TITLE
chore: Change build Python versions to 3.8 - 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version:  ["3.8", "3.9", "3.10", "3.11"]
 
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Drop support for 3.6, 3.7. Test support for 3.10, 3.11.